### PR TITLE
collapse files from `lib` in the diffs

### DIFF
--- a/gitattributes
+++ b/gitattributes
@@ -1,0 +1,1 @@
+lib/ linguist-generated=true


### PR DESCRIPTION
This will show diffs in github with files from the `lib` directory collapsed by the default