### PR TITLE
Load run data on demand

### DIFF
--- a/lib/actions/simpl.js
+++ b/lib/actions/simpl.js
@@ -168,7 +168,7 @@ exports.popError = popError;
 var showGenericError = (0, _reduxActions.createAction)('simpl/SHOW_GENERIC_ERROR');
 /**
  * Given a run id, returns a recursive representation of that run and
- * its children worlds. Sets state.loaded_run to the run id.
+ * its children worlds and players. Sets state.loaded_run to the run id.
  * @function
  * @memberof Simpl.actions.simpl
  * @param {number} run id - the run id on simpl-games-api.
@@ -176,8 +176,8 @@ var showGenericError = (0, _reduxActions.createAction)('simpl/SHOW_GENERIC_ERROR
  */
 
 exports.showGenericError = showGenericError;
-var loadRunData = (0, _reduxActions.createAction)('simpl/LOAD_WORLDS', function (id) {
-  return _autobahn.default.call("model:model.run.".concat(id, ".get_scope_tree"), []);
+var loadRunData = (0, _reduxActions.createAction)('simpl/LOAD_RUN_DATA', function (id) {
+  return _autobahn.default.call("model:model.run.".concat(id, ".get_run_data"), []);
 });
 /**
  * Unload worlds and their children. Sets state.loaded_run to null.

--- a/lib/actions/simpl.js
+++ b/lib/actions/simpl.js
@@ -172,12 +172,13 @@ var showGenericError = (0, _reduxActions.createAction)('simpl/SHOW_GENERIC_ERROR
  * @function
  * @memberof Simpl.actions.simpl
  * @param {number} run id - the run id on simpl-games-api.
+ * @param {bool} loadPlayerScenarios - loads player scenarios if true
  * @returns {NamedReduxAction}
  */
 
 exports.showGenericError = showGenericError;
-var loadRunData = (0, _reduxActions.createAction)('simpl/LOAD_RUN_DATA', function (id) {
-  return _autobahn.default.call("model:model.run.".concat(id, ".get_run_data"), []);
+var loadRunData = (0, _reduxActions.createAction)('simpl/LOAD_RUN_DATA', function (id, loadPlayerScenarios) {
+  return _autobahn.default.call("model:model.run.".concat(id, ".get_run_data"), [loadPlayerScenarios]);
 });
 /**
  * Unload worlds and their children. Sets state.loaded_run to null.

--- a/lib/actions/simpl.js
+++ b/lib/actions/simpl.js
@@ -40,16 +40,13 @@ var getDataTree = (0, _reduxActions.createAction)('simpl/DATATREE_GET', function
  * @function
  * @memberof Simpl.actions.simpl
  * @param {string} scope - the scope's topic
+ * @param {array} excludePlayers - returns only leaders if true
  * @returns {NamedReduxAction}
  */
 
 exports.getDataTree = getDataTree;
-var getRunUsers = (0, _reduxActions.createAction)('simpl/RUNUSERS_GET', function (scope, exclude) {
-  for (var _len = arguments.length, args = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-    args[_key - 2] = arguments[_key];
-  }
-
-  return _autobahn.default.call("".concat(scope, ".get_active_runusers"), args);
+var getRunUsers = (0, _reduxActions.createAction)('simpl/RUNUSERS_GET', function (scope, excludePlayers) {
+  return _autobahn.default.call("".concat(scope, ".get_active_runusers"), [excludePlayers]);
 });
 /**
  * Set the connection status on the store.
@@ -86,8 +83,8 @@ var updateScope = (0, _reduxActions.createAction)('simpl/SCOPE_UPDATE');
 
 exports.updateScope = updateScope;
 var connectedScope = (0, _reduxActions.createAction)('simpl/SCOPE_CONNECTED', function (scope) {
-  for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
-    args[_key2 - 1] = arguments[_key2];
+  for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    args[_key - 1] = arguments[_key];
   }
 
   return _autobahn.default.publish("".concat(scope, ".connected"), args);
@@ -103,32 +100,32 @@ var connectedScope = (0, _reduxActions.createAction)('simpl/SCOPE_CONNECTED', fu
 
 exports.connectedScope = connectedScope;
 var disconnectedScope = (0, _reduxActions.createAction)('simpl/SCOPE_DISCONNECTED', function (topic) {
-  for (var _len3 = arguments.length, args = new Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
-    args[_key3 - 1] = arguments[_key3];
+  for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+    args[_key2 - 1] = arguments[_key2];
   }
 
   return _autobahn.default.publish("".concat(topic, ".disconnected"), args);
 });
 exports.disconnectedScope = disconnectedScope;
 var getCurrentRunPhase = (0, _reduxActions.createAction)('simpl/CURRENT_RUN', function (topic) {
-  for (var _len4 = arguments.length, args = new Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
-    args[_key4 - 1] = arguments[_key4];
+  for (var _len3 = arguments.length, args = new Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+    args[_key3 - 1] = arguments[_key3];
   }
 
   return _autobahn.default.call("".concat(topic, ".get_current_run_and_phase"), args);
 });
 exports.getCurrentRunPhase = getCurrentRunPhase;
 var getPhases = (0, _reduxActions.createAction)('simpl/GET_PHASES', function (topic) {
-  for (var _len5 = arguments.length, args = new Array(_len5 > 1 ? _len5 - 1 : 0), _key5 = 1; _key5 < _len5; _key5++) {
-    args[_key5 - 1] = arguments[_key5];
+  for (var _len4 = arguments.length, args = new Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
+    args[_key4 - 1] = arguments[_key4];
   }
 
   return _autobahn.default.call("".concat(topic, ".get_phases"), args);
 });
 exports.getPhases = getPhases;
 var getRoles = (0, _reduxActions.createAction)('simpl/GET_ROLES', function (topic) {
-  for (var _len6 = arguments.length, args = new Array(_len6 > 1 ? _len6 - 1 : 0), _key6 = 1; _key6 < _len6; _key6++) {
-    args[_key6 - 1] = arguments[_key6];
+  for (var _len5 = arguments.length, args = new Array(_len5 > 1 ? _len5 - 1 : 0), _key5 = 1; _key5 < _len5; _key5++) {
+    args[_key5 - 1] = arguments[_key5];
   }
 
   return _autobahn.default.call("".concat(topic, ".get_roles"), args);

--- a/lib/decorators/simpl.js
+++ b/lib/decorators/simpl.js
@@ -156,15 +156,14 @@ function simpl(options) {
             optionsWithDefaults.topics.forEach(function (topic) {
               // console.log(`dispatching connectedScope(${topic})`);
               dispatch((0, _simpl.connectedScope)(topic));
-              var excludePlayers = options.loadRunDataOnDemand && topic.includes('run') ? true : false;
-              console.log("dispatching getRunUsers(".concat(topic, ", ").concat(excludePlayers, ")"));
+              var excludePlayers = options.loadRunDataOnDemand && topic.includes('run') ? true : false; // console.log(`dispatching getRunUsers(${topic}, ${excludePlayers})`);
+
               dispatch((0, _simpl.getRunUsers)(topic, excludePlayers)).then(function (action) {
                 if (action.error) {
                   throw new Error("".concat(action.payload.error, ": ").concat(action.payload.args.join('; ')));
                 }
 
-                var runUsers = action.payload;
-                console.log("getRunUsers(".concat(topic, ") -> runUsers:"), runUsers);
+                var runUsers = action.payload; // console.log(`getRunUsers(${topic}) -> runUsers:`, runUsers);
 
                 for (var i = 0; i < runUsers.length; i++) {
                   var ru = runUsers[i];

--- a/lib/decorators/simpl.js
+++ b/lib/decorators/simpl.js
@@ -72,7 +72,6 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  *     special: 'org.example.namespace.special.shortcut'
  *   },
  *   loadAllScenarios: false
- *   loadWorldResults: true
  *   loadRunDataOnDemand: false
  * })(MyComponent);
 
@@ -99,8 +98,6 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  * prefixes, to be used as shortcuts.
  * @param {boolean} options.loadAllScenarios - If false, load only world scenarios and this user's Scenarios.
  * If true, load all Scenarios for the subscribed runs.
- * @param {boolean} options.loadWorldResults - If true, load world scenario period decisions and results.
- * If false, load world scenario period decisions but not results.
  * @param {boolean} options.loadRunDataOnDemand - If true, load runs' data on request.
  * If false, load runs' data on login.
  */
@@ -119,18 +116,11 @@ function simpl(options) {
       optionsWithDefaults.loadAllScenarios = false;
     }
 
-    if (options.hasOwnProperty('loadWorldResults')) {
-      optionsWithDefaults.loadWorldResults = options.loadWorldResults;
-    } else {
-      optionsWithDefaults.loadWorldResults = true;
-    }
-
     if (options.hasOwnProperty('loadRunDataOnDemand')) {
-      optionsWithDefaults.loadWorldResults = options.loadRunDataOnDemand;
+      optionsWithDefaults.loadRunDataOnDemand = options.loadRunDataOnDemand;
     } else {
       optionsWithDefaults.loadRunDataOnDemand = false;
     } // console.log(`optionsWithDefaults.loadAllScenarios: ${optionsWithDefaults.loadAllScenarios}`);
-    // console.log(`optionsWithDefaults.loadWorldResults: ${optionsWithDefaults.loadWorldResults}`);
     // console.log(`optionsWithDefaults.loadRunDataOnDemand: ${optionsWithDefaults.loadRunDataOnDemand}`);
     // console.log(`optionsWithDefaults.topics:`, optionsWithDefaults.topics);
 
@@ -206,9 +196,6 @@ function simpl(options) {
                 // console.log(`Will load run's worlds on demand.`);
                 // console.log(`dispatching getDataTree(${topic}, ['world'])`);
                 dispatch((0, _simpl.getDataTree)(topic, ['world']));
-              } else if (!optionsWithDefaults.loadWorldResults && topic.includes('run')) {
-                // console.log(`dispatching getDataTree(${topic}, ['result'])`);
-                dispatch((0, _simpl.getDataTree)(topic, ['result']));
               } else {
                 // console.log(`dispatching getDataTree(${topic})`);
                 dispatch((0, _simpl.getDataTree)(topic));

--- a/lib/decorators/simpl.js
+++ b/lib/decorators/simpl.js
@@ -165,14 +165,16 @@ function simpl(options) {
           if (optionsWithDefaults.topics) {
             optionsWithDefaults.topics.forEach(function (topic) {
               // console.log(`dispatching connectedScope(${topic})`);
-              dispatch((0, _simpl.connectedScope)(topic)); // console.log(`dispatching getRunUsers(${topic})`);
-
-              dispatch((0, _simpl.getRunUsers)(topic)).then(function (action) {
+              dispatch((0, _simpl.connectedScope)(topic));
+              var excludePlayers = options.loadRunDataOnDemand && topic.includes('run') ? true : false;
+              console.log("dispatching getRunUsers(".concat(topic, ", ").concat(excludePlayers, ")"));
+              dispatch((0, _simpl.getRunUsers)(topic, excludePlayers)).then(function (action) {
                 if (action.error) {
                   throw new Error("".concat(action.payload.error, ": ").concat(action.payload.args.join('; ')));
                 }
 
-                var runUsers = action.payload; // console.log(`getRunUsers(${topic}) -> runUsers:`, runUsers);
+                var runUsers = action.payload;
+                console.log("getRunUsers(".concat(topic, ") -> runUsers:"), runUsers);
 
                 for (var i = 0; i < runUsers.length; i++) {
                   var ru = runUsers[i];

--- a/lib/reducers/simpl.js
+++ b/lib/reducers/simpl.js
@@ -351,8 +351,8 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
 }), _defineProperty(_createReducer, SimplActions.loadRunData, function (state, action) {
   var _this4 = this;
 
-  // console.log('SimplActions.loadRunData: run id:', action.payload.pk);
-  // console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
+  console.log('SimplActions.loadRunData: run id:', action.payload.pk); // console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
+
   if (action.payload.error) {
     return this.handleError(state, action);
   }
@@ -374,8 +374,7 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
 
   newState = this.getDataTree(_extends({}, state), action); // load run's worlds
 
-  var runusers = action.payload.runusers; // for (let i = 0; i < runusers.length; i++) {
-  //   const ru = runusers[i];
+  var runusers = action.payload.runusers;
 
   if (!_lodash.default.isEmpty(runusers)) {
     // load run's players
@@ -396,7 +395,7 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
 }), _defineProperty(_createReducer, SimplActions.unloadRunData, function (state, action) {
   var _this5 = this;
 
-  // console.log('SimplActions.unloadRunData: action: ', action);
+  console.log('SimplActions.unloadRunData: action:', action, ', loaded_run:', state.loaded_run);
   var loadedRun = state.loaded_run;
 
   if (_lodash.default.isNil(loadedRun)) {

--- a/lib/reducers/simpl.js
+++ b/lib/reducers/simpl.js
@@ -194,13 +194,10 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
     connectionStatus = _constants.CONNECTION_STATUS.LOADED;
   } else if (connectionStatus === _constants.CONNECTION_STATUS.CONNECTING) {
     connectionStatus = _constants.CONNECTION_STATUS.CONNECTED;
-  } // console.log('SimplActions.getDataTree: connectionStatus=', connectionStatus,
-  //    ', treeLoaded=', state.treeLoaded,
-  //    ', scenariosLoaded=', state.scenariosLoaded,
-  //    ', rolesLoaded', state.rolesLoaded,
-  //    ', phasesLoaded', state.phasesLoaded);
+  }
 
-
+  console.log('SimplActions.getDataTree: connectionStatus=', connectionStatus, ', treeLoaded=', state.treeLoaded, ', scenariosLoaded=', state.scenariosLoaded, ', rolesLoaded', state.rolesLoaded, ', phasesLoaded', state.phasesLoaded);
+  console.log('SimplActions.getDataTree: action.payload:', action.payload);
   return _extends({}, this.getDataTree(_extends({}, state), action), {
     treeLoaded: true,
     connectionStatus: connectionStatus
@@ -348,7 +345,10 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
     errors: errors
   });
 }), _defineProperty(_createReducer, SimplActions.loadRunData, function (state, action) {
-  // console.log('SimplActions.loadRunData: run id:', action.payload.pk);
+  console.log('SimplActions.loadRunData: run id:', action.payload.pk);
+  console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
+  console.log('SimplActions.loadRunData: data_tree:', action.payload.data_tree);
+
   if (action.payload.error) {
     return this.handleError(state, action);
   }
@@ -359,14 +359,10 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
     connectionStatus = _constants.CONNECTION_STATUS.LOADED;
   } else if (connectionStatus === _constants.CONNECTION_STATUS.CONNECTING) {
     connectionStatus = _constants.CONNECTION_STATUS.CONNECTED;
-  } // console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus,
-  //    ', treeLoaded=', state.treeLoaded,
-  //    ', scenariosLoaded=', state.scenariosLoaded,
-  //    ', rolesLoaded', state.rolesLoaded,
-  //    ', phasesLoaded', state.phasesLoaded);
+  }
 
-
-  return _extends({}, this.getDataTree(_extends({}, state), action), {
+  console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus, ', treeLoaded=', state.treeLoaded, ', scenariosLoaded=', state.scenariosLoaded, ', rolesLoaded', state.rolesLoaded, ', phasesLoaded', state.phasesLoaded);
+  return _extends({}, this.getDataTree(_extends({}, state), action.payload.data_tree), {
     treeLoaded: true,
     connectionStatus: connectionStatus,
     loaded_run: action.payload.pk

--- a/lib/reducers/simpl.js
+++ b/lib/reducers/simpl.js
@@ -194,10 +194,14 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
     connectionStatus = _constants.CONNECTION_STATUS.LOADED;
   } else if (connectionStatus === _constants.CONNECTION_STATUS.CONNECTING) {
     connectionStatus = _constants.CONNECTION_STATUS.CONNECTED;
-  }
+  } // console.log('SimplActions.getDataTree: connectionStatus=', connectionStatus,
+  //    ', treeLoaded=', state.treeLoaded,
+  //    ', scenariosLoaded=', state.scenariosLoaded,
+  //    ', rolesLoaded', state.rolesLoaded,
+  //    ', phasesLoaded', state.phasesLoaded);
+  // console.log('SimplActions.getDataTree: action.payload:', action.payload);
 
-  console.log('SimplActions.getDataTree: connectionStatus=', connectionStatus, ', treeLoaded=', state.treeLoaded, ', scenariosLoaded=', state.scenariosLoaded, ', rolesLoaded', state.rolesLoaded, ', phasesLoaded', state.phasesLoaded);
-  console.log('SimplActions.getDataTree: action.payload:', action.payload);
+
   return _extends({}, this.getDataTree(_extends({}, state), action), {
     treeLoaded: true,
     connectionStatus: connectionStatus
@@ -347,9 +351,8 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
 }), _defineProperty(_createReducer, SimplActions.loadRunData, function (state, action) {
   var _this4 = this;
 
-  console.log('SimplActions.loadRunData: run id:', action.payload.pk);
-  console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
-
+  // console.log('SimplActions.loadRunData: run id:', action.payload.pk);
+  // console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
   if (action.payload.error) {
     return this.handleError(state, action);
   }
@@ -360,9 +363,12 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
     connectionStatus = _constants.CONNECTION_STATUS.LOADED;
   } else if (connectionStatus === _constants.CONNECTION_STATUS.CONNECTING) {
     connectionStatus = _constants.CONNECTION_STATUS.CONNECTED;
-  }
+  } // console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus,
+  //   ', treeLoaded=', state.treeLoaded,
+  //   ', scenariosLoaded=', state.scenariosLoaded,
+  //   ', rolesLoaded', state.rolesLoaded,
+  //   ', phasesLoaded', state.phasesLoaded);
 
-  console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus, ', treeLoaded=', state.treeLoaded, ', scenariosLoaded=', state.scenariosLoaded, ', rolesLoaded', state.rolesLoaded, ', phasesLoaded', state.phasesLoaded);
 
   var newState = _objectSpread({}, state);
 

--- a/lib/reducers/simpl.js
+++ b/lib/reducers/simpl.js
@@ -408,10 +408,6 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
   var _this5 = this;
 
   // console.log('SimplActions.unloadRunData: action:', action, ', loaded_run:', state.loaded_run);
-  if (action.payload.error) {
-    return this.handleError(state, action);
-  }
-
   var loadedRun = state.loaded_run;
 
   if (_lodash.default.isNil(loadedRun)) {

--- a/lib/reducers/simpl.js
+++ b/lib/reducers/simpl.js
@@ -351,7 +351,9 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
 }), _defineProperty(_createReducer, SimplActions.loadRunData, function (state, action) {
   var _this4 = this;
 
-  console.log('SimplActions.loadRunData: run id:', action.payload.pk); // console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
+  // console.log('SimplActions.loadRunData: run id:', action.payload.pk);
+  // console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
+  console.log('SimplActions.loadRunData: player_scenarios:', action.payload.player_scenarios);
 
   if (action.payload.error) {
     return this.handleError(state, action);
@@ -384,6 +386,17 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
           payload: ru
         });
       }
+    });
+  }
+
+  var playerScenarios = action.payload.player_scenarios;
+
+  if (!_lodash.default.isEmpty(playerScenarios)) {
+    // load run's player scenarios
+    playerScenarios.forEach(function (scenario) {
+      newState = _this4.getDataTree(newState, {
+        payload: scenario
+      });
     });
   }
 
@@ -447,6 +460,31 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
     runusers.forEach(function (ru) {
       if (!ru.leader) {
         // console.log('remove player:', ru);
+        // unload player scenarios
+        var scenarios = state.scenario.filter(function (s) {
+          return ru.id === s.runuser;
+        });
+        scenarios.forEach(function (scenario) {
+          var periods = state.period.filter(function (p) {
+            return scenario.id === p.scenario;
+          });
+          periods.forEach(function (period) {
+            var decisions = state.decision.filter(function (d) {
+              return period.id === d.period;
+            });
+            decisions.forEach(function (decision) {
+              newState = _this5.removeChild(newState, decision);
+            });
+            var results = state.result.filter(function (r) {
+              return period.id === r.period;
+            });
+            results.forEach(function (result) {
+              newState = _this5.removeChild(newState, result);
+            });
+            newState = _this5.removeChild(newState, period);
+          });
+          newState = _this5.removeChild(newState, scenario);
+        });
         newState = _this5.removeChild(newState, ru);
       }
     });

--- a/lib/reducers/simpl.js
+++ b/lib/reducers/simpl.js
@@ -345,9 +345,10 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
     errors: errors
   });
 }), _defineProperty(_createReducer, SimplActions.loadRunData, function (state, action) {
+  var _this4 = this;
+
   console.log('SimplActions.loadRunData: run id:', action.payload.pk);
   console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
-  console.log('SimplActions.loadRunData: data_tree:', action.payload.data_tree);
 
   if (action.payload.error) {
     return this.handleError(state, action);
@@ -362,13 +363,32 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
   }
 
   console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus, ', treeLoaded=', state.treeLoaded, ', scenariosLoaded=', state.scenariosLoaded, ', rolesLoaded', state.rolesLoaded, ', phasesLoaded', state.phasesLoaded);
-  return _extends({}, this.getDataTree(_extends({}, state), action.payload.data_tree), {
+
+  var newState = _objectSpread({}, state);
+
+  newState = this.getDataTree(_extends({}, state), action); // load run's worlds
+
+  var runusers = action.payload.runusers; // for (let i = 0; i < runusers.length; i++) {
+  //   const ru = runusers[i];
+
+  if (!_lodash.default.isEmpty(runusers)) {
+    // load run's players
+    runusers.forEach(function (ru) {
+      if (!ru.leader) {
+        newState = _this4.addChild(newState, {
+          payload: ru
+        });
+      }
+    });
+  }
+
+  return _extends({}, newState, {
     treeLoaded: true,
     connectionStatus: connectionStatus,
     loaded_run: action.payload.pk
   });
 }), _defineProperty(_createReducer, SimplActions.unloadRunData, function (state, action) {
-  var _this4 = this;
+  var _this5 = this;
 
   // console.log('SimplActions.unloadRunData: action: ', action);
   var loadedRun = state.loaded_run;
@@ -384,7 +404,7 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
   if (!_lodash.default.isEmpty(worlds)) {
     worlds.forEach(function (world) {
       // console.log('remove topic for world:', world);
-      newState = _this4.removeTopic(newState, world); // console.log('unload children of world');
+      newState = _this5.removeTopic(newState, world); // console.log('unload children of world');
 
       var scenarios = state.scenario.filter(function (s) {
         return world.id === s.world;
@@ -398,19 +418,32 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
             return period.id === d.period;
           });
           decisions.forEach(function (decision) {
-            newState = _this4.removeChild(newState, decision);
+            newState = _this5.removeChild(newState, decision);
           });
           var results = state.result.filter(function (r) {
             return period.id === r.period;
           });
           results.forEach(function (result) {
-            newState = _this4.removeChild(newState, result);
+            newState = _this5.removeChild(newState, result);
           });
-          newState = _this4.removeChild(newState, period);
+          newState = _this5.removeChild(newState, period);
         });
-        newState = _this4.removeChild(newState, scenario);
+        newState = _this5.removeChild(newState, scenario);
       });
-      newState = _this4.removeChild(newState, world);
+      newState = _this5.removeChild(newState, world);
+    });
+  }
+
+  var runusers = newState.runuser; // only one run is loaded at a time.
+  // console.log('runusers:', runusers);
+
+  if (!_lodash.default.isEmpty(runusers)) {
+    // unload run's players
+    runusers.forEach(function (ru) {
+      if (!ru.leader) {
+        // console.log('remove player:', ru);
+        newState = _this5.removeChild(newState, ru);
+      }
     });
   }
 

--- a/lib/reducers/simpl.js
+++ b/lib/reducers/simpl.js
@@ -353,8 +353,7 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
 
   // console.log('SimplActions.loadRunData: run id:', action.payload.pk);
   // console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
-  console.log('SimplActions.loadRunData: player_scenarios:', action.payload.player_scenarios);
-
+  // console.log('SimplActions.loadRunData: player_scenarios:', action.payload.player_scenarios);
   if (action.payload.error) {
     return this.handleError(state, action);
   }
@@ -408,7 +407,11 @@ var simpl = (0, _reduxRecycle.default)((0, _reduxCreateReducer.createReducer)(in
 }), _defineProperty(_createReducer, SimplActions.unloadRunData, function (state, action) {
   var _this5 = this;
 
-  console.log('SimplActions.unloadRunData: action:', action, ', loaded_run:', state.loaded_run);
+  // console.log('SimplActions.unloadRunData: action:', action, ', loaded_run:', state.loaded_run);
+  if (action.payload.error) {
+    return this.handleError(state, action);
+  }
+
   var loadedRun = state.loaded_run;
 
   if (_lodash.default.isNil(loadedRun)) {

--- a/src/actions/simpl.js
+++ b/src/actions/simpl.js
@@ -133,10 +133,11 @@ export const showGenericError = createAction('simpl/SHOW_GENERIC_ERROR');
  * @function
  * @memberof Simpl.actions.simpl
  * @param {number} run id - the run id on simpl-games-api.
+ * @param {bool} loadPlayerScenarios - loads player scenarios if true
  * @returns {NamedReduxAction}
  */
-export const loadRunData = createAction('simpl/LOAD_RUN_DATA', (id) => (
-  AutobahnReact.call(`model:model.run.${id}.get_run_data`, [])
+export const loadRunData = createAction('simpl/LOAD_RUN_DATA', (id, loadPlayerScenarios) => (
+  AutobahnReact.call(`model:model.run.${id}.get_run_data`, [loadPlayerScenarios])
 ));
 
 /**

--- a/src/actions/simpl.js
+++ b/src/actions/simpl.js
@@ -29,10 +29,11 @@ export const getDataTree = createAction('simpl/DATATREE_GET', (scope, exclude) =
  * @function
  * @memberof Simpl.actions.simpl
  * @param {string} scope - the scope's topic
+ * @param {array} excludePlayers - returns only leaders if true
  * @returns {NamedReduxAction}
  */
-export const getRunUsers = createAction('simpl/RUNUSERS_GET', (scope, exclude, ...args) => (
-  AutobahnReact.call(`${scope}.get_active_runusers`, args)
+export const getRunUsers = createAction('simpl/RUNUSERS_GET', (scope, excludePlayers) => (
+  AutobahnReact.call(`${scope}.get_active_runusers`, [excludePlayers])
 ));
 
 /**

--- a/src/actions/simpl.js
+++ b/src/actions/simpl.js
@@ -129,14 +129,14 @@ export const showGenericError = createAction('simpl/SHOW_GENERIC_ERROR');
 
 /**
  * Given a run id, returns a recursive representation of that run and
- * its children worlds. Sets state.loaded_run to the run id.
+ * its children worlds and players. Sets state.loaded_run to the run id.
  * @function
  * @memberof Simpl.actions.simpl
  * @param {number} run id - the run id on simpl-games-api.
  * @returns {NamedReduxAction}
  */
-export const loadRunData = createAction('simpl/LOAD_WORLDS', (id) => (
-  AutobahnReact.call(`model:model.run.${id}.get_scope_tree`, [])
+export const loadRunData = createAction('simpl/LOAD_RUN_DATA', (id) => (
+  AutobahnReact.call(`model:model.run.${id}.get_run_data`, [])
 ));
 
 /**

--- a/src/decorators/simpl.js
+++ b/src/decorators/simpl.js
@@ -123,13 +123,14 @@ export function simpl(options) {
             optionsWithDefaults.topics.forEach((topic) => {
               // console.log(`dispatching connectedScope(${topic})`);
               dispatch(connectedScope(topic));
-              // console.log(`dispatching getRunUsers(${topic})`);
-              dispatch(getRunUsers(topic)).then((action) => {
+              const excludePlayers = (options.loadRunDataOnDemand && topic.includes('run')) ? true : false;
+              console.log(`dispatching getRunUsers(${topic}, ${excludePlayers})`);
+              dispatch(getRunUsers(topic, excludePlayers)).then((action) => {
                 if (action.error) {
                   throw new Error(`${action.payload.error}: ${action.payload.args.join('; ')}`);
                 }
                 const runUsers = action.payload;
-                // console.log(`getRunUsers(${topic}) -> runUsers:`, runUsers);
+                console.log(`getRunUsers(${topic}) -> runUsers:`, runUsers);
                 for (let i = 0; i < runUsers.length; i++) {
                   const ru = runUsers[i];
                   const ruTopic = `model:model.runuser.${ru.data.id}`;

--- a/src/decorators/simpl.js
+++ b/src/decorators/simpl.js
@@ -33,7 +33,6 @@ import { wampOptionsWithDefaults, wampSetup } from './utils';
  *     special: 'org.example.namespace.special.shortcut'
  *   },
  *   loadAllScenarios: false
- *   loadWorldResults: true
  *   loadRunDataOnDemand: false
  * })(MyComponent);
 
@@ -60,8 +59,6 @@ import { wampOptionsWithDefaults, wampSetup } from './utils';
  * prefixes, to be used as shortcuts.
  * @param {boolean} options.loadAllScenarios - If false, load only world scenarios and this user's Scenarios.
  * If true, load all Scenarios for the subscribed runs.
- * @param {boolean} options.loadWorldResults - If true, load world scenario period decisions and results.
- * If false, load world scenario period decisions but not results.
  * @param {boolean} options.loadRunDataOnDemand - If true, load runs' data on request.
  * If false, load runs' data on login.
  */
@@ -77,18 +74,12 @@ export function simpl(options) {
     } else {
       optionsWithDefaults.loadAllScenarios = false;
     }
-    if (options.hasOwnProperty('loadWorldResults')) {
-      optionsWithDefaults.loadWorldResults = options.loadWorldResults;
-    } else {
-      optionsWithDefaults.loadWorldResults = true;
-    }
     if (options.hasOwnProperty('loadRunDataOnDemand')) {
-      optionsWithDefaults.loadWorldResults = options.loadRunDataOnDemand;
+      optionsWithDefaults.loadRunDataOnDemand = options.loadRunDataOnDemand;
     } else {
       optionsWithDefaults.loadRunDataOnDemand = false;
     }
     // console.log(`optionsWithDefaults.loadAllScenarios: ${optionsWithDefaults.loadAllScenarios}`);
-    // console.log(`optionsWithDefaults.loadWorldResults: ${optionsWithDefaults.loadWorldResults}`);
     // console.log(`optionsWithDefaults.loadRunDataOnDemand: ${optionsWithDefaults.loadRunDataOnDemand}`);
     // console.log(`optionsWithDefaults.topics:`, optionsWithDefaults.topics);
 
@@ -156,9 +147,6 @@ export function simpl(options) {
                 // console.log(`Will load run's worlds on demand.`);
                 // console.log(`dispatching getDataTree(${topic}, ['world'])`);
                 dispatch(getDataTree(topic, ['world']));
-              } else if (!optionsWithDefaults.loadWorldResults && topic.includes('run')) {
-                // console.log(`dispatching getDataTree(${topic}, ['result'])`);
-                dispatch(getDataTree(topic, ['result']));
               } else {
                 // console.log(`dispatching getDataTree(${topic})`);
                 dispatch(getDataTree(topic));

--- a/src/decorators/simpl.js
+++ b/src/decorators/simpl.js
@@ -115,13 +115,13 @@ export function simpl(options) {
               // console.log(`dispatching connectedScope(${topic})`);
               dispatch(connectedScope(topic));
               const excludePlayers = (options.loadRunDataOnDemand && topic.includes('run')) ? true : false;
-              console.log(`dispatching getRunUsers(${topic}, ${excludePlayers})`);
+              // console.log(`dispatching getRunUsers(${topic}, ${excludePlayers})`);
               dispatch(getRunUsers(topic, excludePlayers)).then((action) => {
                 if (action.error) {
                   throw new Error(`${action.payload.error}: ${action.payload.args.join('; ')}`);
                 }
                 const runUsers = action.payload;
-                console.log(`getRunUsers(${topic}) -> runUsers:`, runUsers);
+                // console.log(`getRunUsers(${topic}) -> runUsers:`, runUsers);
                 for (let i = 0; i < runUsers.length; i++) {
                   const ru = runUsers[i];
                   const ruTopic = `model:model.runuser.${ru.data.id}`;

--- a/src/reducers/simpl.js
+++ b/src/reducers/simpl.js
@@ -138,12 +138,12 @@ const simpl = recycleState(createReducer(initial, {
     } else if (connectionStatus === CONNECTION_STATUS.CONNECTING) {
       connectionStatus = CONNECTION_STATUS.CONNECTED;
     }
-    // console.log('SimplActions.getDataTree: connectionStatus=', connectionStatus,
-    //    ', treeLoaded=', state.treeLoaded,
-    //    ', scenariosLoaded=', state.scenariosLoaded,
-    //    ', rolesLoaded', state.rolesLoaded,
-    //    ', phasesLoaded', state.phasesLoaded);
-
+    console.log('SimplActions.getDataTree: connectionStatus=', connectionStatus,
+       ', treeLoaded=', state.treeLoaded,
+       ', scenariosLoaded=', state.scenariosLoaded,
+       ', rolesLoaded', state.rolesLoaded,
+       ', phasesLoaded', state.phasesLoaded);
+    console.log('SimplActions.getDataTree: action.payload:', action.payload);
     return Object.assign({}, this.getDataTree(Object.assign({}, state), action), {
       treeLoaded: true,
       connectionStatus,
@@ -270,7 +270,9 @@ const simpl = recycleState(createReducer(initial, {
     return Object.assign({}, state, { errors });
   },
   [SimplActions.loadRunData](state, action) {
-    // console.log('SimplActions.loadRunData: run id:', action.payload.pk);
+    console.log('SimplActions.loadRunData: run id:', action.payload.pk);
+    console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
+    console.log('SimplActions.loadRunData: data_tree:', action.payload.data_tree);
     if (action.payload.error) {
       return this.handleError(state, action);
     }
@@ -280,12 +282,12 @@ const simpl = recycleState(createReducer(initial, {
     } else if (connectionStatus === CONNECTION_STATUS.CONNECTING) {
       connectionStatus = CONNECTION_STATUS.CONNECTED;
     }
-    // console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus,
-    //    ', treeLoaded=', state.treeLoaded,
-    //    ', scenariosLoaded=', state.scenariosLoaded,
-    //    ', rolesLoaded', state.rolesLoaded,
-    //    ', phasesLoaded', state.phasesLoaded);
-    return Object.assign({}, this.getDataTree(Object.assign({}, state), action), {
+    console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus,
+       ', treeLoaded=', state.treeLoaded,
+       ', scenariosLoaded=', state.scenariosLoaded,
+       ', rolesLoaded', state.rolesLoaded,
+       ', phasesLoaded', state.phasesLoaded);
+    return Object.assign({}, this.getDataTree(Object.assign({}, state), action.payload.data_tree), {
       treeLoaded: true,
       connectionStatus,
       loaded_run: action.payload.pk,

--- a/src/reducers/simpl.js
+++ b/src/reducers/simpl.js
@@ -272,7 +272,7 @@ const simpl = recycleState(createReducer(initial, {
   [SimplActions.loadRunData](state, action) {
     // console.log('SimplActions.loadRunData: run id:', action.payload.pk);
     // console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
-    console.log('SimplActions.loadRunData: player_scenarios:', action.payload.player_scenarios);
+    // console.log('SimplActions.loadRunData: player_scenarios:', action.payload.player_scenarios);
     if (action.payload.error) {
       return this.handleError(state, action);
     }
@@ -294,7 +294,7 @@ const simpl = recycleState(createReducer(initial, {
       // load run's players
       runusers.forEach(ru => {
         if (!ru.leader) {
-          newState = this.addChild(newState, {payload: ru});
+          newState = this.addChild(newState, { payload: ru });
         }
       });
     }
@@ -312,7 +312,10 @@ const simpl = recycleState(createReducer(initial, {
     });
   },
   [SimplActions.unloadRunData](state, action) {
-    console.log('SimplActions.unloadRunData: action:', action, ', loaded_run:', state.loaded_run);
+    // console.log('SimplActions.unloadRunData: action:', action, ', loaded_run:', state.loaded_run);
+    if (action.payload.error) {
+      return this.handleError(state, action);
+    }
     const loadedRun = state.loaded_run;
     if (_.isNil(loadedRun)) {
       return state;

--- a/src/reducers/simpl.js
+++ b/src/reducers/simpl.js
@@ -313,9 +313,6 @@ const simpl = recycleState(createReducer(initial, {
   },
   [SimplActions.unloadRunData](state, action) {
     // console.log('SimplActions.unloadRunData: action:', action, ', loaded_run:', state.loaded_run);
-    if (action.payload.error) {
-      return this.handleError(state, action);
-    }
     const loadedRun = state.loaded_run;
     if (_.isNil(loadedRun)) {
       return state;

--- a/src/reducers/simpl.js
+++ b/src/reducers/simpl.js
@@ -138,12 +138,12 @@ const simpl = recycleState(createReducer(initial, {
     } else if (connectionStatus === CONNECTION_STATUS.CONNECTING) {
       connectionStatus = CONNECTION_STATUS.CONNECTED;
     }
-    console.log('SimplActions.getDataTree: connectionStatus=', connectionStatus,
-       ', treeLoaded=', state.treeLoaded,
-       ', scenariosLoaded=', state.scenariosLoaded,
-       ', rolesLoaded', state.rolesLoaded,
-       ', phasesLoaded', state.phasesLoaded);
-    console.log('SimplActions.getDataTree: action.payload:', action.payload);
+    // console.log('SimplActions.getDataTree: connectionStatus=', connectionStatus,
+    //    ', treeLoaded=', state.treeLoaded,
+    //    ', scenariosLoaded=', state.scenariosLoaded,
+    //    ', rolesLoaded', state.rolesLoaded,
+    //    ', phasesLoaded', state.phasesLoaded);
+    // console.log('SimplActions.getDataTree: action.payload:', action.payload);
     return Object.assign({}, this.getDataTree(Object.assign({}, state), action), {
       treeLoaded: true,
       connectionStatus,
@@ -270,8 +270,8 @@ const simpl = recycleState(createReducer(initial, {
     return Object.assign({}, state, { errors });
   },
   [SimplActions.loadRunData](state, action) {
-    console.log('SimplActions.loadRunData: run id:', action.payload.pk);
-    console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
+    // console.log('SimplActions.loadRunData: run id:', action.payload.pk);
+    // console.log('SimplActions.loadRunData: runusers:', action.payload.runusers);
     if (action.payload.error) {
       return this.handleError(state, action);
     }
@@ -281,11 +281,11 @@ const simpl = recycleState(createReducer(initial, {
     } else if (connectionStatus === CONNECTION_STATUS.CONNECTING) {
       connectionStatus = CONNECTION_STATUS.CONNECTED;
     }
-    console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus,
-      ', treeLoaded=', state.treeLoaded,
-      ', scenariosLoaded=', state.scenariosLoaded,
-      ', rolesLoaded', state.rolesLoaded,
-      ', phasesLoaded', state.phasesLoaded);
+    // console.log('SimplActions.loadRunData: connectionStatus=', connectionStatus,
+    //   ', treeLoaded=', state.treeLoaded,
+    //   ', scenariosLoaded=', state.scenariosLoaded,
+    //   ', rolesLoaded', state.rolesLoaded,
+    //   ', phasesLoaded', state.phasesLoaded);
     let newState = { ...state };
     newState = this.getDataTree(Object.assign({}, state), action); // load run's worlds
     const runusers = action.payload.runusers;

--- a/src/reducers/simpl.js
+++ b/src/reducers/simpl.js
@@ -289,8 +289,6 @@ const simpl = recycleState(createReducer(initial, {
     let newState = { ...state };
     newState = this.getDataTree(Object.assign({}, state), action); // load run's worlds
     const runusers = action.payload.runusers;
-    // for (let i = 0; i < runusers.length; i++) {
-    //   const ru = runusers[i];
     if (!_.isEmpty(runusers)) {
       // load run's players
       runusers.forEach(ru => {
@@ -306,7 +304,7 @@ const simpl = recycleState(createReducer(initial, {
     });
   },
   [SimplActions.unloadRunData](state, action) {
-    // console.log('SimplActions.unloadRunData: action: ', action);
+    // console.log('SimplActions.unloadRunData: action:', action, ', loaded_run:', state.loaded_run);
     const loadedRun = state.loaded_run;
     if (_.isNil(loadedRun)) {
       return state;


### PR DESCRIPTION
- Extends simpl decorator loadRunDataOnDemand to include run's players.
- Extends simpl action loadRunData to load run's players and optionally load run's player scenarios.
- Removes obsolete simpl decorator loadWorldResults option.

Depends on changes in simpl-modelservice load-run-data-on-demand branch.